### PR TITLE
modify script to copy english strings

### DIFF
--- a/update_languages_android.sh
+++ b/update_languages_android.sh
@@ -12,6 +12,7 @@ fi
 source supported_languages_mobile.sh
 
 ./update-translations.sh
+cp probe-mobile/en/strings.xml ${PROJDIR}/app/src/main/res/values/
 for language in "${SUPPORTED_LANGUAGES[@]}";do
     lang=$(basename ${language} | sed 's/zh_CN/zh_rCN/' | sed 's/zh_TW/zh_rTW/' | sed 's/pt_BR/pt_rBR/' | tr '_' '-' )
     dst_path="${PROJDIR}/app/src/main/res/values-${lang}/"

--- a/update_languages_ios.sh
+++ b/update_languages_ios.sh
@@ -12,7 +12,7 @@ fi
 source supported_languages_mobile.sh
 
 ./update-translations.sh
-cp probe-mobile/en//Localizable.strings ${PROJDIR}/ooniprobe/Base.lproj/
+cp probe-mobile/en/Localizable.strings ${PROJDIR}/ooniprobe/Base.lproj/
 for language in "${SUPPORTED_LANGUAGES[@]}";do
     lang=$(basename ${language} | sed 's/zh_CN/zh-Hans/' | sed 's/zh_TW/zh-Hant/' | sed 's/pt_BR/pt-BR/')
     dst_path="${PROJDIR}/ooniprobe/${lang}.lproj/"

--- a/update_languages_ios.sh
+++ b/update_languages_ios.sh
@@ -12,6 +12,7 @@ fi
 source supported_languages_mobile.sh
 
 ./update-translations.sh
+cp probe-mobile/en//Localizable.strings ${PROJDIR}/ooniprobe/Base.lproj/
 for language in "${SUPPORTED_LANGUAGES[@]}";do
     lang=$(basename ${language} | sed 's/zh_CN/zh-Hans/' | sed 's/zh_TW/zh-Hant/' | sed 's/pt_BR/pt-BR/')
     dst_path="${PROJDIR}/ooniprobe/${lang}.lproj/"


### PR DESCRIPTION
When running 
`./update_languages_ios.sh` or `./update_languages_android.sh`
The original english strings are not copied into the app repo for two reasons:
1) `en` is not in the `supported_languages_mobile.sh` array (and its correct, for the reason 2)
2) There is no `en` folder in Android (simply called `values`) or iOS (called `Base`)

So the fix is manually copy the en file into the relative folder before cycling the `supported_languages_mobile.sh` array